### PR TITLE
Fix result of parameter benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ BenchmarkSliceReadLastItemFirst-8          	  500000	      3140 ns/op
 ## Passing a parameter by value vs pointer
 
 ```
-BenchmarkParameterSlicePassedByValue-8     	    5000	    268002 ns/op
-BenchmarkParameterSlicePassedByPointer-8   	  500000	      3138 ns/op
+BenchmarkParameterSlicePassedByValue-8     	  500000	      2624 ns/op
+BenchmarkParameterSlicePassedByPointer-8   	  500000	      2518 ns/op
 ```
 
 ## Using reflect vs cast


### PR DESCRIPTION
The benchmark itself was fixed in 34a11a0a32d62334f0c96e10184ccf45336cc098 but the result in the README is still based on the old benchmark.

Even better would be to improve the benchmark it self by using a big struct instead of just a slice header as argument. Right now you're benchmarking the difference between using a slice header which is 24 bytes as argument vs a pointer which is 8 bytes as argument.

If you want I can create a pull request to change it to have a big struct as argument. See: https://gist.github.com/erikdubbelboer/98c8a910b1151c6df0e1ecba56fffcec