### PR TITLE
Add more slice benchmarks & comparison with container/list

### DIFF
--- a/slice_test.go
+++ b/slice_test.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"container/list"
 	"testing"
 )
 
@@ -69,6 +70,43 @@ func BenchmarkSliceFillMakeAppend(b *testing.B) {
 		m := make([]int, 0, BenchMarkSize)
 		for i := 0; i < BenchMarkSize; i++ {
 			m = append(m, i)
+		}
+	}
+}
+
+func BenchmarkSliceFillAppendNoMake(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		m := []int{}
+
+		for i := 0; i < BenchMarkSize; i++ {
+			m = append(m, i)
+		}
+	}
+}
+
+func BenchmarkSliceFillSmallMakeAppend(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		m := make([]int, 0, BenchMarkSize/10)
+		for i := 0; i < BenchMarkSize; i++ {
+			m = append(m, i)
+		}
+	}
+}
+
+func BenchmarkFillLinkedListPushBack(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		l := list.New()
+		for i := 0; i < BenchMarkSize; i++ {
+			l.PushBack("a")
+		}
+	}
+}
+
+func BenchmarkFillLinkedListPushFront(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		l := list.New()
+		for i := 0; i < BenchMarkSize; i++ {
+			l.PushFront("a")
 		}
 	}
 }


### PR DESCRIPTION
Hi there,

I just added a few more benchmarks on lists.

Results below:

```
➜  go-benchmark git:(master) go test -v -benchmem -bench=Fill
goos: linux
goarch: amd64
pkg: github.com/cornelk/go-benchmark
BenchmarkSliceFillByIndex-8           	 3000000	       445 ns/op	       0 B/op	       0 allocs/op
BenchmarkSliceFillByIndexMake-8       	 2000000	       642 ns/op	       0 B/op	       0 allocs/op
BenchmarkSliceFillMakeAppend-8        	 3000000	       509 ns/op	       0 B/op	       0 allocs/op
BenchmarkSliceFillAppendNoMake-8      	  500000	      2855 ns/op	   16376 B/op	      11 allocs/op
BenchmarkSliceFillSmallMakeAppend-8   	  500000	      2235 ns/op	   14080 B/op	       3 allocs/op
BenchmarkFillLinkedListPushBack-8     	   50000	     34202 ns/op	   49200 B/op	    1025 allocs/op
BenchmarkFillLinkedListPushFront-8    	   50000	     33992 ns/op	   49200 B/op	    1025 allocs/op
PASS
ok  	github.com/cornelk/go-benchmark	12.542s
➜  go-benchmark git:(master) 
```